### PR TITLE
Reworked display engine. 

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -6,7 +6,7 @@
 #define MEGAFM_CONSTANTS_H
 
 const byte kVersion0 = 3;
-const byte kVersion1 = 0;
+const byte kVersion1 = 1;
 
 const byte kDefaultSeq[16] = {0, 0, 0, 0, 12, 12, 12, 12, 0, 0, 12, 0, 0, 12, 12, 0};
 

--- a/include/leds.h
+++ b/include/leds.h
@@ -18,4 +18,5 @@ void showPickup();
 void digit(byte channel, byte number);
 void showAlgo(byte number);
 void ledSet(byte number, bool value);
+void showNumber(byte movedPotOrFader, byte value);
 #endif // MEGAFM_CMAKE_LEDS_H

--- a/include/megafm.h
+++ b/include/megafm.h
@@ -22,13 +22,15 @@ extern bool noRecAction;
 extern bool recHeld;
 extern bool showLfoFlag;
 extern int showSSEGCounter;
+extern int showPresetNumberTimeout; // we show the preset number when this expires (after moving a knob or fader);
+extern bool timeToShowPresetNumber; // set true when timeout expires
 extern byte SSEG[4];
 extern byte lastOperator;
 extern bool secPast;
 extern byte lastSentCC[2];
 extern byte lastSentMega[2];
 extern byte lastSentYm[2];
-
+extern int displayFreeze; // when >0 show only preset number after preset change
 extern bool fatSpreadMode;
 constexpr bool FAT_SPREAD_MODE_1DOWN2UP = false; // chip 1 down, chip 2 up
 constexpr bool FAT_SPREAD_MODE_MIXED = true;     // both chips go up and downa

--- a/src/ISR.cpp
+++ b/src/ISR.cpp
@@ -57,8 +57,16 @@ void isr() {
 		}
 	}
 
+	if (showPresetNumberTimeout) {
+		showPresetNumberTimeout--;
+		if (!showPresetNumberTimeout)
+			timeToShowPresetNumber = true;
+	}
 	if (updatePitchCounter < 20)
 		updatePitchCounter++;
+
+	if (displayFreeze)
+		displayFreeze--;
 
 	if (showSSEGCounter) {
 		showSSEGCounter--;

--- a/src/MEGAfm.cpp
+++ b/src/MEGAfm.cpp
@@ -222,6 +222,9 @@ int fmData[51], fmDataLast[51];
 bool linked[3][51];
 bool dontShow[51];
 byte lfoRandom[3][32];
+int displayFreeze;
+int showPresetNumberTimeout; // we show the preset number when this expires (after moving a knob or fader);
+bool timeToShowPresetNumber; // set true when timeout expires
 byte randomIndex[3];
 bool pressedUp, pressedDown;
 bool saved;

--- a/src/leds.cpp
+++ b/src/leds.cpp
@@ -53,114 +53,85 @@
 #include "megafm.h"
 #include "voice.h"
 
-void updateLedNumber() {
+void showNumber(byte movedPotOrFader, byte value) {
 
 	int theNumber = -1;
 
-	for (byte ledNumberIndex = 0; ledNumberIndex < 49; ledNumberIndex++) {
+	switch (movedPotOrFader) {
 
-		switch (ledNumberIndex) {
+		case 2:
+		case 11:
+		case 20:
+		case 29:
+		case 37:
+		case 39:
+		case 41:
+		case 49:
+			theNumber = value >> 2;
+			break; //>>2
 
-			case 2:
-			case 11:
-			case 20:
-			case 29:
-			case 37:
-			case 39:
-			case 41:
-			case 49:
-				if (fmBaseLastNumber[ledNumberIndex] != fmBase[ledNumberIndex] >> 2) {
-					fmBaseLastNumber[ledNumberIndex] = fmBase[ledNumberIndex] >> 2;
-					theNumber = (fmBaseLastNumber[ledNumberIndex]);
-				}
-				break; //>>2
+		case 4:
+		case 5:
+		case 6:
+		case 13:
+		case 14:
+		case 15:
+		case 22:
+		case 23:
+		case 24:
+		case 31:
+		case 32:
+		case 33:
+			theNumber = value >> 3;
+			break; //>>3
 
-			case 4:
-			case 5:
-			case 6:
-			case 13:
-			case 14:
-			case 15:
-			case 22:
-			case 23:
-			case 24:
-			case 31:
-			case 32:
-			case 33:
-				if (fmBaseLastNumber[ledNumberIndex] != fmBase[ledNumberIndex] >> 3) {
-					fmBaseLastNumber[ledNumberIndex] = fmBase[ledNumberIndex] >> 3;
-					theNumber = (fmBaseLastNumber[ledNumberIndex]);
-				}
-				break; //>>3
+		case 7:
+		case 35:
+		case 8:
+		case 16:
+		case 17:
+		case 25:
+		case 26:
+		case 34:
+			theNumber = value >> 4;
+			break; //>>4
 
-			case 7:
-			case 35:
-			case 8:
-			case 16:
-			case 17:
-			case 25:
-			case 26:
-			case 34:
-				if (fmBaseLastNumber[ledNumberIndex] != fmBase[ledNumberIndex] >> 4) {
-					fmBaseLastNumber[ledNumberIndex] = fmBase[ledNumberIndex] >> 4;
-					theNumber = (fmBaseLastNumber[ledNumberIndex]);
-				}
-				break; //>>4
+		case 1:
+		case 10:
+		case 19:
+		case 28:
+			theNumber = value >> 4;
+			if (!theNumber) {
+				theNumber = 666;
+			}
 
-			case 1:
-			case 10:
-			case 19:
-			case 28:
-				if (fmBaseLastNumber[ledNumberIndex] != fmBase[ledNumberIndex] >> 4) {
-					fmBaseLastNumber[ledNumberIndex] = fmBase[ledNumberIndex] >> 4;
-					theNumber = (fmBaseLastNumber[ledNumberIndex]);
-					if (!theNumber) {
-						theNumber = 666;
-					}
-				}
-				break; // mult
+			break; // mult
 
-			case 43:
-				if (fmBaseLastNumber[ledNumberIndex] != fmBase[ledNumberIndex] >> 5) {
-					fmBaseLastNumber[ledNumberIndex] = fmBase[ledNumberIndex] >> 5;
-					theNumber = (fmBaseLastNumber[ledNumberIndex]);
-				}
-				break; //>>5
+		case 43:
+			theNumber = value >> 5;
+			break; //>>5
 
-			case 42:
-				if (fmBaseLastNumber[ledNumberIndex] != fmBase[ledNumberIndex] >> 5) {
-					fmBaseLastNumber[ledNumberIndex] = fmBase[ledNumberIndex] >> 5;
-					theNumber = (1 + fmBaseLastNumber[ledNumberIndex]);
-				}
-				break; //>>5 +1
+		case 42:
+			theNumber = value >> 5;
+			theNumber++;
+			break; //>>5 +1
 
-			case 47:
-				if (fmBaseLastNumber[ledNumberIndex] != fmBase[ledNumberIndex] >> 6) {
-					fmBaseLastNumber[ledNumberIndex] = fmBase[ledNumberIndex] >> 6;
-					theNumber = (1 + fmBaseLastNumber[ledNumberIndex]);
-				}
-				break; //>>6 +1
-		}
-		if (dontShow[ledNumberIndex]) {
-			theNumber = -1;
-		}
+		case 47:
+			theNumber = value >> 6;
+			theNumber++;
+			break; //>>6 +1
 	}
+	if (theNumber != -1)
+		ledNumber(theNumber);
+}
 
-	if (!setupMode) {
-		if (preset != presetLast) {
-			presetLast = preset;
-			lastNumber = -1;
-			ledNumber(preset);
-		}
-	} else {
+void updateLedNumber() {
+
+	if (setupMode) {
 		if (!setupChanged) {
 			digit(0, 5);
 			digit(1, 18);
 		}
-	}
-
-	if ((theNumber != -1) && (!ledNumberTimeOut)) {
-		ledNumber(theNumber);
 	}
 }
 
@@ -267,30 +238,31 @@ void showSendReceive() {
 }
 
 void ledNumber(int value) {
-
-	if (value == 666) { //.5
-		digit(0, 21);
-		digit(1, 5);
-		mydisplay.setLed(0, 7, 6, 1);
-		lastNumber = value;
-	} else {
-
-		dotTimer = 10;
-
-		if (value < 0) {
-			if (value > -10) {
-				digit(0, 20); // minus
-				digit(1, -value);
-				lastNumber = value;
-			}
+	if (!displayFreeze) {
+		if (value == 666) { //.5
+			digit(0, 21);
+			digit(1, 5);
+			mydisplay.setLed(0, 7, 6, 1);
+			lastNumber = value;
 		} else {
-			if (value > 99)
-				value = 99;
 
-			if (lastNumber != value) {
-				lastNumber = value;
-				digit(0, value / 10);
-				digit(1, value - ((value / 10) * 10));
+			dotTimer = 10;
+
+			if (value < 0) {
+				if (value > -10) {
+					digit(0, 20); // minus
+					digit(1, -value);
+					lastNumber = value;
+				}
+			} else {
+				if (value > 99)
+					value = 99;
+
+				if (lastNumber != value) {
+					lastNumber = value;
+					digit(0, value / 10);
+					digit(1, value - ((value / 10) * 10));
+				}
 			}
 		}
 	}

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -371,4 +371,9 @@ void loop() {
 	if (pickupMode && pickupAnimationNewFrame && showPickupAnimation) {
 		showPickup();
 	}
+
+	if (timeToShowPresetNumber) {
+		timeToShowPresetNumber = false;
+		ledNumber(preset);
+	}
 }

--- a/src/pots.cpp
+++ b/src/pots.cpp
@@ -201,6 +201,8 @@ void movedPot(byte number, byte data, bool isMidi) {
 			} else {
 
 				// not setup mode
+				if (!isMidi)
+					showPresetNumberTimeout = 12000;
 
 				if ((pickupMode) && (!pickup[number])) {
 					// param hasn't been picked up yet, tel user if its too high or low
@@ -223,6 +225,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 0;
+
 								sendCC(number, data >> 1);
 							}
 							dontShow[0] = isMidi;
@@ -234,6 +237,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 1;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							dontShow[1] = isMidi;
@@ -245,6 +249,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 2;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							dontShow[2] = isMidi;
@@ -256,6 +261,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 4;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							dontShow[4] = isMidi;
@@ -267,6 +273,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 5;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							dontShow[5] = isMidi;
@@ -278,6 +285,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 7;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							dontShow[7] = isMidi;
@@ -289,6 +297,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 6;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							dontShow[6] = isMidi;
@@ -300,6 +309,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 8;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							dontShow[8] = isMidi;
@@ -330,6 +340,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 19;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // multiple
@@ -341,6 +352,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 20;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // op level
@@ -352,6 +364,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 22;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // attack WAS 59
@@ -363,6 +376,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 23;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // decay1 WAS 50
@@ -374,6 +388,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 25;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // sustain WAS 60
@@ -385,6 +400,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 24;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // sustain rate WAS 55
@@ -396,6 +412,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 26;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // release WAS 52
@@ -425,6 +442,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 10;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // multiple
@@ -436,6 +454,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 11;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // op level
@@ -447,6 +466,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 13;
+								showNumber(targetPot, data);
 								sendCC(49, data >> 1);
 							}
 							break; // attack
@@ -458,6 +478,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 14;
+								showNumber(targetPot, data);
 								sendCC(50, data >> 1);
 							}
 							break; // decay1
@@ -469,6 +490,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 16;
+								showNumber(targetPot, data);
 								sendCC(51, data >> 1);
 							}
 							break; // sustain
@@ -480,6 +502,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 15;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // sustain rate
@@ -491,6 +514,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 17;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // release
@@ -509,6 +533,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 27;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // detune
@@ -520,6 +545,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 28;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // multiple
@@ -531,6 +557,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 29;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // op level
@@ -542,6 +569,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 31;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // attack
@@ -553,6 +581,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 32;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // decay1
@@ -564,6 +593,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 34;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // sustain
@@ -575,6 +605,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 33;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // sustain rate
@@ -586,6 +617,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if (!isMidi) {
 								isFader = true;
 								targetPot = 35;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // release
@@ -628,6 +660,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							dontShow[42] = isMidi;
 							if (!isMidi) {
 								targetPot = 42;
+								showNumber(targetPot, data);
 								sendCC(number, (1 + (data >> 5)));
 							}
 							break; // algo
@@ -639,6 +672,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							dontShow[43] = isMidi;
 							if (!isMidi) {
 								targetPot = 43;
+								showNumber(targetPot, data);
 								sendCC(number, (data >> 1));
 							}
 							break; // feedback
@@ -694,7 +728,9 @@ void movedPot(byte number, byte data, bool isMidi) {
 									} // show number of bars (b1 or b2 or b4)
 
 								} else {
-									ledNumber(data >> 2);
+									if (!isMidi) {
+										ledNumber(data >> 2);
+									}
 								}
 								if (!isMidi) {
 									targetPot = 36;
@@ -710,6 +746,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							selectedLfo = 0;
 							if (!isMidi) {
 								targetPot = 37;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // lfo 1 depth
@@ -727,7 +764,8 @@ void movedPot(byte number, byte data, bool isMidi) {
 								if ((lfoClockEnable[1]) && (sync)) {
 									ledNumber(kArpRateDisplay[data >> 5]);
 								} else {
-									ledNumber(data >> 2);
+									if (!isMidi)
+										ledNumber(data >> 2);
 								}
 								if (!isMidi) {
 									targetPot = 38;
@@ -743,6 +781,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							selectedLfo = 1;
 							if (!isMidi) {
 								targetPot = 39;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // lfo 2 depth
@@ -760,7 +799,8 @@ void movedPot(byte number, byte data, bool isMidi) {
 								if ((lfoClockEnable[2]) && (sync)) {
 									ledNumber(kArpRateDisplay[data >> 5]);
 								} else {
-									ledNumber(data >> 2);
+									if (!isMidi)
+										ledNumber(data >> 2);
 								}
 								if (!isMidi) {
 									targetPot = 40;
@@ -776,6 +816,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							selectedLfo = 2;
 							if (!isMidi) {
 								targetPot = 41;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // lfo 3 depth
@@ -789,7 +830,8 @@ void movedPot(byte number, byte data, bool isMidi) {
 								ledNumber(kArpRateDisplay[data >> 5]);
 								arpMidiSpeedPending = data >> 5;
 							} else {
-								ledNumber(data >> 2);
+								if (!isMidi)
+									ledNumber(data >> 2);
 							}
 							if (!isMidi) {
 								targetPot = 46;
@@ -806,6 +848,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							dontShow[47] = isMidi;
 							if (!isMidi) {
 								targetPot = 47;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // arp range
@@ -818,7 +861,8 @@ void movedPot(byte number, byte data, bool isMidi) {
 							if ((vibratoClockEnable) && (sync)) {
 								ledNumber(data >> 5);
 							} else {
-								ledNumber(data >> 3);
+								if (!isMidi)
+									ledNumber(data >> 3);
 							}
 							if (!isMidi) {
 								targetPot = 48;
@@ -832,6 +876,7 @@ void movedPot(byte number, byte data, bool isMidi) {
 							dontShow[49] = isMidi;
 							if (!isMidi) {
 								targetPot = 49;
+								showNumber(targetPot, data);
 								sendCC(number, data >> 1);
 							}
 							break; // vibrato depth

--- a/src/preset.cpp
+++ b/src/preset.cpp
@@ -413,6 +413,10 @@ void loadPreset() {
 	for (int i = 0; i < 4; i++) {
 		updateSSEG(i);
 	}
+
+	displayFreeze = 0;
+	ledNumber(preset);
+	displayFreeze = 12000;
 }
 
 void savePreset() {


### PR DESCRIPTION
Preset number is no longer interrupted by other loaded values
show preset number again if no faders nor pots are moved for a couple of seconds
fixed a bug preventing faders to update display under some conditions